### PR TITLE
DC and Zone for "unique id" concideration

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -88,6 +88,8 @@ unit        | in what is the magnititude being measured.  see below
 file        | file (that generated a metric)
 line        | line (that generated a metric)
 env         | environment
+dc          | datacenter
+zone        | zone
 
 
 ### Special tag values


### PR DESCRIPTION
Add zone/dc tags to the "unique metric id" tag set.  While possible to insert into the "what" tag, makes it much more explicit.
